### PR TITLE
Trap when logging in with an anonymous Principal

### DIFF
--- a/backend/Main.mo
+++ b/backend/Main.mo
@@ -43,8 +43,10 @@ actor class Main() {
 
   func assertCallerIsUser(caller : Principal) : Types.User.Id {
     assert not Principal.isAnonymous(caller);
-    let ?user = principals.get(caller) else { assert false; loop {} };
-    user;
+    switch (principals.get(caller)) {
+      case null { assert false; loop {} };
+      case (?user) user;
+    };
   };
 
   func assertCallerOwnsTopic(caller : Principal, topic : Types.Topic.Id) {


### PR DESCRIPTION
Fixes a corner case where users could create an account with an anonymous principal.