### PR TITLE
Add `canister_ids.json`

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,0 +1,12 @@
+{
+    "backend": {
+      "ic": "qwmau-siaaa-aaaap-aa5cq-cai"
+    },
+    "frontend": {
+      "ic": "q7pli-eaaaa-aaaap-aa5da-cai"
+    },
+    "internet_identity": {
+      "id": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+    }
+  }
+  


### PR DESCRIPTION
Specifies mainnet canister IDs for simplified deployment. 