### PR TITLE
Unescape HTML in Jira topic titles

### DIFF
--- a/src/utils/parseJiraXml.ts
+++ b/src/utils/parseJiraXml.ts
@@ -33,7 +33,7 @@ export default function parseJiraXml(xml: string): ImportTopic[] {
   // TODO: detect topic status from 'status' field when possible
 
   return [...doc.getElementsByTagName('item')].map((item) => {
-    let title = getField(item, 'title');
+    let title = htmlDecode(getField(item, 'title'));
     // Move Jira identifier to end of title
     title = title.replace(/^\[([^\]]+)\]\s(.+)$/, '$2 ($1)');
 


### PR DESCRIPTION
Safely unescapes substrings such as `&lt;` in imported Jira titles.