### PR TITLE
Prefer recent activity, even in vote order.

### DIFF
--- a/backend/Core.mo
+++ b/backend/Core.mo
@@ -237,10 +237,16 @@ module {
             case (#votes) {
               // Compare size of net votes.
               // More goes first, meaning bigger is "less".
-              Int.compare(
-                t2.upVoters : Int - t2.downVoters,
-                t1.upVoters : Int - t1.downVoters,
-              );
+              // For equal vote count, prefer topics with recent activity/votes.
+              switch (
+                Int.compare(
+                  t2.upVoters : Int - t2.downVoters,
+                  t1.upVoters : Int - t1.downVoters,
+                )
+              ) {
+                case (#equal) Int.compare(topicTime(t2), topicTime(t1));
+                case ord ord;
+              };
             };
             case (#activity) {
               // Prefer topics with recent votes.


### PR DESCRIPTION
When vote counts are equal, vote order uses activity ordering.

That way, 
- gives more useful view of vote ordering, especially with lots of zero votes, or equal vote counts.
- switching between the two orderings causes the least change in the topics' position.