### PR TITLE
Log cycles balance.

### DIFF
--- a/backend/History.mo
+++ b/backend/History.mo
@@ -81,14 +81,14 @@ module {
   public type Event = {
     #install : {
       time : Int; // nano seconds
-      cycles_balance : ?Nat;
+      cyclesBalance : ?Nat;
       installer : Principal;
     };
     #request : {
       requestId : RequestId;
       time : Int; // nano seconds
       caller : Principal;
-      cycles_balance : ?Nat;
+      cyclesBalance : ?Nat;
       request : Request;
     };
     #internal : {
@@ -112,10 +112,10 @@ module {
   };
 
   public func init(installer : Principal) : History {
-    let cycles_balance = ?Cycles.balance();
+    let cyclesBalance = ?Cycles.balance();
     {
       var nextRequestId = 1;
-      var events = Seq.make(#install { time = Time.now(); installer; cycles_balance });
+      var events = Seq.make(#install { time = Time.now(); installer; cyclesBalance });
     };
   };
 
@@ -178,8 +178,8 @@ module {
       let requestId = history.nextRequestId;
       do {
         history.nextRequestId += 1;
-        let cycles_balance = ?Cycles.balance();
-        add(#request { time = Time.now(); caller; request; requestId; cycles_balance });
+        let cyclesBalance = ?Cycles.balance();
+        add(#request { time = Time.now(); caller; request; requestId; cyclesBalance });
       };
 
       func addResponse(response : Response) {


### PR DESCRIPTION
Log keeps a `cycles_balance` field in each request event, to track how cycles are used over time.

Can be used to generate plots of cycles versus request messages, or find strangely-expensive parts of the interface.

-----

### Upgrade story:

- Necessarily, the new field in the log event record is optional.

- [dx.internetcomputer.org](dx.internetcomputer.org) is running an instance of `main` branch with thousands of events already logged.  Each of those existing events will have a `null` value for the new `cyclesBalance` after upgrade.

- All events created after the upgrade will contain a non-null `cyclesBalance` field, using the new logic in this PR.

- A local test using Motoko Dev Server concludes what we expect, that:
  - upgrading to an optional new field works as expected.
  - upgrading to a non-optional new field breaks the program logic, since existing records already held in the canister do not have it.