### PR TITLE
`setTopicModStatus` accepts an optional message for `#rejected`.

### DIFF
--- a/backend/Core.mo
+++ b/backend/Core.mo
@@ -435,7 +435,7 @@ module {
               };
               // TODO: moderation for approved topic edits
               modStatus = switch (topic.modStatus) {
-                case (#rejected) #pending;
+                case (#rejected _) #pending;
                 case (s) s;
               };
             };

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -15,7 +15,7 @@ module {
 
     public type Status = { #open; #next; #completed; #closed };
 
-    public type ModStatus = { #pending; #approved; #rejected };
+    public type ModStatus = { #pending; #approved; #rejected : ?Text };
 
     public type UserVote = { #up; #down; #none };
 

--- a/src/components/TopicView.tsx
+++ b/src/components/TopicView.tsx
@@ -33,6 +33,7 @@ import Tooltip from './Tooltip';
 import TopicForm from './TopicForm';
 import TopicTag from './TopicTag';
 import { Join } from './utils/Join';
+import { promptModMessage } from '../utils/promptModMessage';
 
 const ToolbarButton = tw.div`flex items-center gap-2 font-bold px-4 py-2 text-sm rounded-full cursor-pointer border-2 bg-[#fff8] border-gray-300 hover:bg-[rgba(0,0,0,.05)]`;
 
@@ -304,7 +305,13 @@ export default function TopicView({
                           <Tooltip content="Hide">
                             <ToolbarButton
                               // css={{ background: statusColors.next }}
-                              onClick={() => setModStatus(topic, 'rejected')}
+                              onClick={() =>
+                                handlePromise(
+                                  promptModMessage(topic, 'rejected'),
+                                  undefined,
+                                  'Error while updating topic status!',
+                                )
+                              }
                             >
                               {' '}
                               <FaFlag tw="text-red-600" />

--- a/src/components/TopicView.tsx
+++ b/src/components/TopicView.tsx
@@ -280,7 +280,16 @@ export default function TopicView({
                     )}
                   </div>
                 )}
-              {(!!topic.isEditable || !!user?.detail.isModerator) &&
+              {!!(topic.isEditable && topic.modMessage) && (
+                <div tw="">
+                  <div tw="flex gap-2">
+                    <FaTimes tw="text-red-600 translate-y-[3px]" />
+                    <div tw="font-bold">Moderator note:</div>
+                    <div tw="opacity-75">{topic.modMessage}</div>
+                  </div>
+                </div>
+              )}
+              {!!(topic.isEditable || user?.detail.isModerator) &&
                 !hideModerationInfo && (
                   <div tw="flex gap-2 mt-4">
                     <div tw="flex flex-1">

--- a/src/components/pages/QueuePage.tsx
+++ b/src/components/pages/QueuePage.tsx
@@ -6,6 +6,7 @@ import { ModStatus, Topic, useTopicStore } from '../../stores/topicStore';
 import { handleError } from '../../utils/handlers';
 import Loading from '../Loading';
 import TopicView from '../TopicView';
+import { promptModMessage } from '../../utils/promptModMessage';
 
 const ModeratorButton = tw.div`flex items-center gap-2 font-bold px-3 py-3 text-xl rounded-full cursor-pointer border-2 bg-[#fffd] border-gray-300 hover:scale-105`;
 
@@ -28,7 +29,12 @@ export default function QueuePage() {
   }, [getModQueue, user]);
 
   const changeModStatus = (topic: Topic, modStatus: ModStatus) => {
-    setModStatus(topic, modStatus).catch((err) => {
+    const promise =
+      modStatus === 'rejected'
+        ? promptModMessage(topic, modStatus)
+        : setModStatus(topic, modStatus);
+
+    promise.catch((err) => {
       handleError(err, 'Error while changing topic status!');
     });
     // if (topics) {

--- a/src/stores/topicStore.ts
+++ b/src/stores/topicStore.ts
@@ -28,6 +28,7 @@ export interface Topic extends TopicInfo {
   downvotes: number;
   status: TopicStatus;
   modStatus: ModStatus;
+  modMessage: string;
   isOwner: boolean;
   isEditable: boolean;
   yourVote: VoteStatus;
@@ -103,6 +104,7 @@ export const useTopicStore = create<TopicState>((set, get) => {
     downvotes: Number(result.downVoters),
     status: Object.keys(result.status)[0] as TopicStatus,
     modStatus: Object.keys(result.modStatus)[0] as ModStatus,
+    modMessage: result.modStatus.rejected?.[0] || '',
     yourVote: 'up' in result.yourVote ? 1 : 'down' in result.yourVote ? -1 : 0,
     importId: result.importId.length
       ? mapImportId(result.importId[0])

--- a/src/stores/topicStore.ts
+++ b/src/stores/topicStore.ts
@@ -104,7 +104,8 @@ export const useTopicStore = create<TopicState>((set, get) => {
     downvotes: Number(result.downVoters),
     status: Object.keys(result.status)[0] as TopicStatus,
     modStatus: Object.keys(result.modStatus)[0] as ModStatus,
-    modMessage: result.modStatus.rejected?.[0] || '',
+    modMessage:
+      ('rejected' in result.modStatus && result.modStatus.rejected?.[0]) || '',
     yourVote: 'up' in result.yourVote ? 1 : 'down' in result.yourVote ? -1 : 0,
     importId: result.importId.length
       ? mapImportId(result.importId[0])
@@ -157,6 +158,7 @@ export const useTopicStore = create<TopicState>((set, get) => {
         yourVote: 1,
         status: 'open',
         modStatus: 'pending',
+        modMessage: '',
         isOwner: true,
         isEditable: true,
       };
@@ -222,14 +224,19 @@ export const useTopicStore = create<TopicState>((set, get) => {
       set({ modQueue: topics });
       return topics;
     },
-    async setModStatus(topic: Topic, modStatus: ModStatus) {
+    async setModStatus(
+      topic: Topic,
+      modStatus: ModStatus,
+      modMessage?: string,
+    ) {
       updateTopic({
         ...topic,
         modStatus,
+        modMessage: modMessage || '',
       });
       unwrap(
         await backend.setTopicModStatus(BigInt(topic.id), {
-          [modStatus]: null,
+          [modStatus]: modMessage || null,
         } as any),
       );
     },

--- a/src/stores/topicStore.ts
+++ b/src/stores/topicStore.ts
@@ -61,7 +61,11 @@ export interface TopicState {
   vote(topic: Topic, vote: VoteStatus): Promise<void>;
   setStatus(id: string, status: TopicStatus): Promise<void>;
   fetchModQueue(): Promise<Topic[]>;
-  setModStatus(topic: Topic, modStatus: ModStatus): Promise<void>;
+  setModStatus(
+    topic: Topic,
+    modStatus: ModStatus,
+    modMessage?: string,
+  ): Promise<void>;
 }
 
 export const useTopicStore = create<TopicState>((set, get) => {
@@ -236,7 +240,8 @@ export const useTopicStore = create<TopicState>((set, get) => {
       });
       unwrap(
         await backend.setTopicModStatus(BigInt(topic.id), {
-          [modStatus]: modMessage || null,
+          [modStatus]:
+            modStatus === 'rejected' ? (modMessage ? [modMessage] : []) : null,
         } as any),
       );
     },

--- a/src/utils/promptModMessage.ts
+++ b/src/utils/promptModMessage.ts
@@ -1,0 +1,20 @@
+import Swal from 'sweetalert2';
+import { ModStatus, Topic, useTopicStore } from '../stores/topicStore';
+
+export async function promptModMessage(
+  topic: Topic,
+  modStatus: ModStatus,
+): Promise<string | undefined> {
+  const result = await Swal.fire({
+    title: 'Message (optional):',
+    showCancelButton: true,
+    confirmButtonColor: '#7450c3', // TODO: refactor
+    input: 'text',
+  });
+  if (!result.isConfirmed) {
+    return;
+  }
+  const modMessage = result.value || '';
+  await useTopicStore.getState().setModStatus(topic, modStatus, modMessage);
+  return modMessage;
+}

--- a/src/utils/promptModMessage.ts
+++ b/src/utils/promptModMessage.ts
@@ -6,10 +6,11 @@ export async function promptModMessage(
   modStatus: ModStatus,
 ): Promise<string | undefined> {
   const result = await Swal.fire({
-    title: 'Message (optional):',
+    title: 'Moderator note:',
     showCancelButton: true,
     confirmButtonColor: '#7450c3', // TODO: refactor
     input: 'text',
+    inputPlaceholder: '(Leave blank for default)',
   });
   if (!result.isConfirmed) {
     return;


### PR DESCRIPTION
accept, save and view moderator's optional reject message about a topic.

### Backend upgrade and testing story
- Needs to be optional `Text`, for upgrades from existing datasets to work.
- [x] Upgrading from `main` with existing history into this branch works locally, using dev server.
- [x] Tested setTopicModStatus, using `dfx` to give a reject message for a new topic.  Works.
- [x] Tested that log and topic view each contain the reject message.

### Frontend changes
- [x] Refactored client-side topic representation
- [x] Added input dialog
- [x] Included moderator message in topic UI when relevant