### PR TITLE
Require moderator permissions to change pending topic status

### DIFF
--- a/backend/Core.mo
+++ b/backend/Core.mo
@@ -474,7 +474,7 @@ module {
     public func setTopicStatus(caller : Principal, id : Types.Topic.RawId, status : Types.Topic.Status) : ?() {
       do ? {
         let log = logger.Begin(caller, #setTopicStatus { topic = #topic id; status });
-        assertCallerCanEdit(log, caller, #topic id)!;
+        assertCallerIsModerator(log, caller)!;
         state.topics.update(#topic id, func(topic : Types.Topic.State) : Types.Topic.State { { topic with status; stamp = { topic.stamp with statusTime = Time.now() } } });
         log.ok()!;
       };

--- a/src/components/TopicView.tsx
+++ b/src/components/TopicView.tsx
@@ -329,45 +329,48 @@ export default function TopicView({
                         )}
                       </div>
                     )}
-                    <div tw="flex gap-2">
-                      {topic.status === 'open' && (
-                        <ToolbarButton
-                          // css={{ background: statusColors.next }}
-                          onClick={() => onChangeStatus(topic, 'next')}
-                        >
-                          <FaRegPlayCircle />
-                          Start
-                        </ToolbarButton>
-                      )}
-                      {topic.status === 'next' && (
-                        <ToolbarButton
-                          // css={{ background: statusColors.completed }}
-                          onClick={() => onChangeStatus(topic, 'completed')}
-                        >
-                          <FaRegCheckCircle />
-                          Complete
-                        </ToolbarButton>
-                      )}
-                      {(topic.status === 'open' || topic.status === 'next') && (
-                        <ToolbarButton
-                          // css={{ background: statusColors.closed }}
-                          onClick={() => onChangeStatus(topic, 'closed')}
-                        >
-                          <FaRegTimesCircle />
-                          Close
-                        </ToolbarButton>
-                      )}
-                      {(topic.status === 'completed' ||
-                        topic.status === 'closed') && (
-                        <ToolbarButton
-                          // css={{ background: statusColors.open }}
-                          onClick={() => onChangeStatus(topic, 'open')}
-                        >
-                          <FaRegDotCircle />
-                          Reopen
-                        </ToolbarButton>
-                      )}
-                    </div>
+                    {!!user?.detail.isModerator && (
+                      <div tw="flex gap-2">
+                        {topic.status === 'open' && (
+                          <ToolbarButton
+                            // css={{ background: statusColors.next }}
+                            onClick={() => onChangeStatus(topic, 'next')}
+                          >
+                            <FaRegPlayCircle />
+                            Start
+                          </ToolbarButton>
+                        )}
+                        {topic.status === 'next' && (
+                          <ToolbarButton
+                            // css={{ background: statusColors.completed }}
+                            onClick={() => onChangeStatus(topic, 'completed')}
+                          >
+                            <FaRegCheckCircle />
+                            Complete
+                          </ToolbarButton>
+                        )}
+                        {(topic.status === 'open' ||
+                          topic.status === 'next') && (
+                          <ToolbarButton
+                            // css={{ background: statusColors.closed }}
+                            onClick={() => onChangeStatus(topic, 'closed')}
+                          >
+                            <FaRegTimesCircle />
+                            Close
+                          </ToolbarButton>
+                        )}
+                        {(topic.status === 'completed' ||
+                          topic.status === 'closed') && (
+                          <ToolbarButton
+                            // css={{ background: statusColors.open }}
+                            onClick={() => onChangeStatus(topic, 'open')}
+                          >
+                            <FaRegDotCircle />
+                            Reopen
+                          </ToolbarButton>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
             </Join>


### PR DESCRIPTION
This PR hides the status change buttons from topic owners, instead requiring a moderator to change the status.