### PR TITLE
Configure ESBuild to rewrite `global` as `globalThis`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,14 +36,7 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [
-          'babel-plugin-twin',
-          'babel-plugin-macros',
-          // [
-          //   'babel-plugin-styled-components',
-          //   { displayName: true, fileName: false },
-          // ],
-        ],
+        plugins: ['babel-plugin-twin', 'babel-plugin-macros'],
         ignore: ['\x00commonjsHelpers.js'], // Fix build error (ben-rogerson/babel-plugin-twin#9)
       },
     }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
     imagetools(),
   ],
   define: {
-    global: 'globalThis', // Patch CBOR library used in agent-js
     'process.env.DFX_NETWORK': JSON.stringify(process.env.DFX_NETWORK),
     // Expose canister IDs provided by `dfx deploy`
     ...Object.fromEntries(
@@ -59,6 +58,14 @@ export default defineConfig({
         JSON.stringify(ids[network] || ids[localNetwork]),
       ]),
     ),
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      define: {
+        // Patch CBOR library used in agent-js
+        global: 'globalThis',
+      },
+    },
   },
   server: {
     // Local IC replica proxy


### PR DESCRIPTION
Resolves a potential issue with web workers described in https://github.com/rvanasa/vite-react-motoko/issues/3. 