### PR TITLE
Reverse-chronological event history.

### DIFF
--- a/backend/Core.mo
+++ b/backend/Core.mo
@@ -540,6 +540,15 @@ module {
       };
     };
 
+    public func getHistory(caller : Principal, size : Nat) : ?[[History.Event]] {
+      do ? {
+        let log = logger.Begin(caller, #moderatorQuery);
+        assertCallerIsModerator(log, caller)!;
+        log.ok()!; // want this response to be included in the result in next line.
+        logger.getHistory(size);
+      };
+    };
+
     public func getLogEvents(caller : Principal, start : Nat, size : Nat) : ?[History.Event] {
       do ? {
         let log = logger.Begin(caller, #moderatorQuery);

--- a/src/components/pages/HistoryPage.tsx
+++ b/src/components/pages/HistoryPage.tsx
@@ -121,9 +121,10 @@ const ResponseEventCard = styled.div`
   }
 `;
 
+const maxEventCount = 1000; // TODO: pagination
+
 export default function HistoryPage() {
   const [events, setEvents] = useState<Event[] | undefined>();
-  const [maxEventCount] = useState(1000); // TODO: adjustable?
 
   const user = useIdentity();
 
@@ -131,15 +132,9 @@ export default function HistoryPage() {
     if (user) {
       (async () => {
         try {
-          const eventCount = unwrap(await backend.getLogEventCount());
-          const minEventNumber = eventCount - BigInt(maxEventCount);
           const events = unwrap(
-            await backend.getLogEvents(
-              minEventNumber < BigInt(0) ? BigInt(0) : minEventNumber,
-              eventCount,
-            ),
+            await backend.getLogEvents(BigInt(0), BigInt(maxEventCount)),
           );
-          // events.reverse(); // Most recent events first
           console.log('Events:', events);
           setEvents(events);
         } catch (err) {
@@ -147,7 +142,7 @@ export default function HistoryPage() {
         }
       })();
     }
-  }, [maxEventCount, user]);
+  }, [user]);
 
   if (!events) {
     return <Loading />;


### PR DESCRIPTION
`getHistory` gets the most recent events, and groups them based on request event placement.

The order of event groups is most recent first (in contrast to the existing ways to get and view the event log, where oldest come first).