### PR TITLE
Refactor front-end unit testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-    env:
-      DFX_VERSION: 0.14.1
 
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +30,7 @@ jobs:
         cache: 'npm'
     - name: Install dfx
       run: |
-        echo y | DFX_VERSION=$DFX_VERSION bash -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+        echo y | bash -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
     - name: Start dfx
       run: |
         dfx cache install

--- a/dfx.json
+++ b/dfx.json
@@ -1,5 +1,4 @@
 {
-  "dfx": "0.14.1",
   "defaults": {
     "build": {
       "packtool": "npm run --silent sources"

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import App from './App';
 import { StrictMode } from 'react';
 
 describe('App', () => {
-  it('renders as expected', () => {
+  test('renders as expected', () => {
     render(
       <StrictMode>
         <App />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-import 'twin.macro';
+import { ToastContainer } from 'react-toastify';
 import useIdentity from '../hooks/useIdentity';
 import { FileDropZone } from './FileDropZone';
 import Navbar from './Navbar';
@@ -10,11 +10,17 @@ import QueuePage from './pages/QueuePage';
 import SubmitPage from './pages/SubmitPage';
 import TopicPage from './pages/TopicPage';
 
+import 'react-toastify/dist/ReactToastify.css';
+import 'tippy.js/dist/tippy.css';
+import 'twin.macro';
+import '../styles/index.scss';
+
 export default function App() {
   const user = useIdentity();
 
   const app = (
     <Router>
+      <ToastContainer position="bottom-right" />
       <div tw="w-screen min-h-screen overflow-x-hidden">
         <Navbar />
         <div tw="max-w-[800px] h-full mx-auto p-4 mt-1">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,27 +1,8 @@
 // import { Auth0Provider } from '@auth0/auth0-react';
 import { createRoot } from 'react-dom/client';
-import { ToastContainer } from 'react-toastify';
 import App from './components/App';
-
-import 'react-toastify/dist/ReactToastify.css';
-import 'tippy.js/dist/tippy.css';
-import 'twin.macro';
-import './styles/index.scss';
 
 const rootElement = document.getElementById('root')!;
 const root = createRoot(rootElement);
 
-root.render(
-  <>
-    {/* <Auth0Provider
-      domain="dev-1t7t4gyh7n17hil2.us.auth0.com"
-      clientId="fAwyAXet0Z3cuJPx2nS0GWnsXN6pVFEi"
-      authorizationParams={{
-        redirect_uri: window.location.origin,
-      }}
-    > */}
-    <ToastContainer position="bottom-right" />
-    <App />
-    {/* </Auth0Provider> */}
-  </>,
-);
+root.render(<App />);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,20 @@
 import matchers from '@testing-library/jest-dom/matchers';
 import 'cross-fetch/polyfill';
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 
 expect.extend(matchers);
+
+// Use local replica in place of Vite dev server
+vi.mock('@dfinity/agent', () => {
+  const { HttpAgent, ...rest } = require('@dfinity/agent');
+  class MockHttpAgent extends HttpAgent {
+    constructor(...args: any[]) {
+      super(...args);
+      (this as any)._host = 'http://127.0.0.1:4943';
+    }
+  }
+  return {
+    ...rest,
+    HttpAgent: MockHttpAgent,
+  };
+});


### PR DESCRIPTION
Fixes a long-standing issue where the default `HttpAgent` URLs pointed to the Vite dev server (instead of local replica) during unit testing. 

Also includes a few other improvements from https://github.com/dfinity/ic-eth-starter/pull/44.