### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,14 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: Install dfx
-      uses: dfinity/setup-dfx@main
+      uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
     - name: Start dfx
       run: |
         dfx cache install


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions/setup-node@v3` -> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1`
  - Version: v3.9.1 | Latest: v6.3.0 | Release age: 36d
  - Commit: https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365


### Files modified

- `.github/workflows/tests.yml`